### PR TITLE
코인과 코인 시세를 만든다

### DIFF
--- a/backend/tick-common/build.gradle.kts
+++ b/backend/tick-common/build.gradle.kts
@@ -21,4 +21,7 @@ dependencies {
 
     // security-crypto
     api("org.springframework.security:spring-security-crypto")
+
+    // webflux
+    api("org.springframework.boot:spring-boot-starter-webflux:3.3.3")
 }

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/Cryptocurrency.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/Cryptocurrency.kt
@@ -1,0 +1,33 @@
+package com.core.cryptocurrency.domain
+
+import com.core.cryptocurrency.domain.vo.CryptocurrencyPlatform
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "cryptocurrency")
+class Cryptocurrency(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = 0L,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name = "platform")
+    val platform: CryptocurrencyPlatform,
+
+    @Column(nullable = false)
+    val market: String,
+
+    @Column(nullable = false, name = "korean_name")
+    val koreanName: String,
+
+    @Column(nullable = false, name = "english_name")
+    val englishName: String,
+) {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyPrice.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyPrice.kt
@@ -1,0 +1,33 @@
+package com.core.cryptocurrency.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "cryptocurrency_price")
+class CryptocurrencyPrice(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = 0L,
+
+    @Column(nullable = false, name = "cryptocurrency_id")
+    val cryptocurrencyId: Long,
+
+    @Column(nullable = false, name = "trade_price")
+    val tradePrice: Double,
+
+    @Column(nullable = false, name = "low_price")
+    val lowPrice: Double,
+
+    @Column(nullable = false, name = "high_price")
+    val highPrice: Double,
+
+    @Column(nullable = false, name = "recorded_at")
+    val recordedAt: LocalDateTime
+) {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyPriceRepository.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyPriceRepository.kt
@@ -1,0 +1,4 @@
+package com.core.cryptocurrency.domain
+
+interface CryptocurrencyPriceRepository {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyRepository.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/CryptocurrencyRepository.kt
@@ -1,0 +1,4 @@
+package com.core.cryptocurrency.domain
+
+interface CryptocurrencyRepository {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/vo/CryptocurrencyPlatform.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/domain/vo/CryptocurrencyPlatform.kt
@@ -1,0 +1,7 @@
+package com.core.cryptocurrency.domain.vo
+
+enum class CryptocurrencyPlatform {
+
+    UPBIT,
+    BITHUMB
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyJpaRepository.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.core.cryptocurrency.infrastructure
+
+import com.core.cryptocurrency.domain.Cryptocurrency
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CryptocurrencyJpaRepository : JpaRepository<Cryptocurrency, Long> {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyPriceJpaRepository.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyPriceJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.core.cryptocurrency.infrastructure
+
+import com.core.cryptocurrency.domain.Cryptocurrency
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CryptocurrencyPriceJpaRepository : JpaRepository<Cryptocurrency, Long> {
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyPriceRepositoryImpl.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyPriceRepositoryImpl.kt
@@ -1,0 +1,10 @@
+package com.core.cryptocurrency.infrastructure
+
+import org.springframework.stereotype.Repository
+
+@Repository
+class CryptocurrencyPriceRepositoryImpl(
+    private val cryptocurrencyPriceJpaRepository: CryptocurrencyPriceJpaRepository
+) {
+
+}

--- a/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyRepositoryImpl.kt
+++ b/backend/tick-core/src/main/kotlin/com/core/cryptocurrency/infrastructure/CryptocurrencyRepositoryImpl.kt
@@ -1,0 +1,10 @@
+package com.core.cryptocurrency.infrastructure
+
+import org.springframework.stereotype.Repository
+
+@Repository
+class CryptocurrencyRepositoryImpl(
+    private val cryptocurrencyJpaRepository: CryptocurrencyJpaRepository
+) {
+
+}


### PR DESCRIPTION
## 📄 Summary

- 코인 Cryptocurrency와 시세 정보인 CryptocurrencyPrice를 생성한다.

Cryptocurrency <-> CryptocurrencyPrice의 관계는 1:N이고 같은 바운디드 컨텍스트라고 볼 수 있지만, 다른 기능 도입이 예정되었고 그때 시점에선 별도로 보는게 유리하다 생각해서 Price에서 Cryptocurrency의 id값만 간접 참조하도록 설계

1. Cryptocurrency (코인)
- 고유한 코인이자, 시장에서의 식별자 역할을 함
- 대다수의 경우 바뀌지 않고 정적이다 (상폐한다면?)
- 코인에 대한 상징적인 도메인으로 사용한다

2. CryptocurrencyPrice (코인 시세)
- 특정 시점의 코인 가치를 의미한다.
- 동적이고 거래소 API와의 상호작용에 의존
- 시간이 지나도 계속 데이터가 생성된다.
- 추후 시세 추이를 위한 분석을 위해 사용된다.
- 추후 시세의 상관관계 분석을 위해 사용된다.


크롤링을 한다면?? 분리한 상황에서 어떨까?
<img width="1217" alt="Image" src="https://github.com/user-attachments/assets/c10fbec4-b6a6-4803-b0bc-17a7afc8849a" />


## 🙋🏻 More

>


close #3